### PR TITLE
Fixed #7

### DIFF
--- a/download.cpp
+++ b/download.cpp
@@ -56,7 +56,7 @@ std::vector<std::string> download::downloadPilotVersions() {
     return versions;
 }
 
-int download::downloadPilotClient(int program, int variant, bool force) {
+std::string download::downloadPilotClient(int program, int variant, bool force) {
 
     std::string programVersion = download::downloadPilotVersions().at(program);
     std::string programName;
@@ -89,7 +89,6 @@ int download::downloadPilotClient(int program, int variant, bool force) {
     CURLcode res;
 
     std::string outputName = "/tmp/vatsim-manager/" + programName + programVersion + "-" + std::to_string(variant) + ".run";
-
     system(("find " + outputName + " > /tmp/vatsim-manager/findinstaller 2>&1")
                    .c_str());
     //TODO better solution for no reaction to if
@@ -98,7 +97,7 @@ int download::downloadPilotClient(int program, int variant, bool force) {
         //TODO detect old versions
         std::cout << "Found installer in /tmp/vatsim-manager/" << std::endl << "If you encounter errors or this is an old " <<
              "installer, use --force-download" << std::endl << std::endl;
-        return 1;
+        return outputName;
     }
 
     FILE* output = fopen(outputName.c_str(), "wb");
@@ -124,7 +123,7 @@ int download::downloadPilotClient(int program, int variant, bool force) {
     curl_easy_cleanup(curl);
     fclose(output);
 
-    return 0;
+    return outputName;
 }
 
 // https://stackoverflow.com/questions/1637587/c-libcurl-console-progress-bar

--- a/download.h
+++ b/download.h
@@ -10,7 +10,7 @@
 class download {
 public:
     static std::vector<std::string> downloadPilotVersions();
-    int downloadPilotClient(int program, int variant, bool force);
+    std::string downloadPilotClient(int program, int variant, bool force);
 private:
     static size_t write_data(char *ptr, size_t size, size_t nmemb, void *userdata);
     static int progress_func(void* ptr, double TotalToDownload, double NowDownloaded, double TotalToUpload,

--- a/main.cpp
+++ b/main.cpp
@@ -41,9 +41,9 @@ int install(const char* program, bool forceDownload) {
 
     string cmdOut;
     if (ut.askForConfirmation(programName.c_str())) {
-        dl.downloadPilotClient(programIndex, programVar, forceDownload);
-        system(("chmod +x /tmp/vatsim-manager/" + programName + ".run").c_str());
-        system(("/tmp/vatsim-manager/" + programName + ".run").c_str());
+        string outFile = dl.downloadPilotClient(programIndex, programVar, forceDownload);
+        system(("chmod +x " + outFile).c_str());
+        system((outFile).c_str());
         cs.createState();
     }
 


### PR DESCRIPTION
Fixed issue #7 where the chmod and execution would not target the correct file in /tmp/vatsim-manager, b/c it didn't take into account version numbers. I just made downloadPilotClient return a string, and set it to return the output file location it used for saving, then set the chmod and execution to use that instead of the original file.